### PR TITLE
fix(radio): update styles to make component consistent

### DIFF
--- a/src/Atoms/Inputs/Checkbox.js
+++ b/src/Atoms/Inputs/Checkbox.js
@@ -9,8 +9,8 @@ const toId = (name) => `${name}-checkbox`
 
 const Wrapper = styled.div`
   input:checked + label::before {
-    background-color: ${(props) => props.theme.inputCheckboxColor};
-    border-color: ${(props) => props.theme.inputCheckboxColor};
+    background-color: ${(props) => props.theme.inputCheckedColor};
+    border-color: ${(props) => props.theme.inputCheckedColor};
   }
 
   input:checked + label::after {
@@ -59,7 +59,7 @@ export const CheckboxLabel: ReactComponentFunctional<{
     box-sizing: border-box;
     content: '';
     height: 16px;
-    left: 0.05rem;
+    left: 1px;
     position: absolute;
     top: calc(50% - 0.5rem);
     width: 16px;

--- a/src/Atoms/Inputs/Radio.js
+++ b/src/Atoms/Inputs/Radio.js
@@ -16,10 +16,11 @@ type InputPropsType = { +name?: string, +type: HtmlInputType } & E2ePropType
 const RadioButton = styled.span`
   margin-right: 0.5rem;
   background: ${({ theme }) => theme.palette.white};
-  border: 2px solid ${({ theme }) => theme.inputRadioColor};
+  border: 2px solid ${(props) => props.theme.inputBorderColor};
+  box-sizing: border-box;
   border-radius: 50%;
-  height: 1.25rem;
-  width: 1.25rem;
+  height: 16px;
+  width: 16px;
 `
 
 const Input: ReactComponentFunctional<InputPropsType> = styled.input.attrs({
@@ -28,23 +29,31 @@ const Input: ReactComponentFunctional<InputPropsType> = styled.input.attrs({
   name: (props) => props.name,
   type: 'radio',
 })`
-  clip: rect(0, 0, 0, 0);
   position: absolute;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  visibility: visible;
+  white-space: nowrap;
+  width: 1px;
 
   &:checked ~ label ${RadioButton} {
     display: flex;
     align-items: center;
     justify-content: center;
-    border-color: ${({ theme }) => theme.inputRadioCheckedColor};
+    border-color: ${(props) => props.theme.inputCheckedColor};
 
     &::before {
       border-radius: 51%;
       content: '';
       display: inline-block;
-      height: 0.75rem;
-      width: 0.75rem;
+      height: 8px;
+      width: 8px;
       position: relative;
-      background: ${({ theme }) => theme.inputRadioCheckedColor};
+      background: ${(props) => props.theme.inputCheckedColor};
     }
   }
 `
@@ -55,10 +64,10 @@ export const RadioLabel: ReactComponentFunctional<{
   htmlFor: (props) => toId(props.value),
 })`
   position: relative;
+  left: 1px;
   display: flex;
   align-items: center;
   min-height: 1rem;
-  padding-left: 0.5rem;
   cursor: pointer;
   font-family: ${(props) => props.theme.fontPrimary};
   font-size: 1rem;

--- a/src/Atoms/Inputs/__snapshots__/Input.spec.js.snap
+++ b/src/Atoms/Inputs/__snapshots__/Input.spec.js.snap
@@ -266,7 +266,7 @@ exports[`Input should render correctly with type="checkbox" 1`] = `
   box-sizing: border-box;
   content: '';
   height: 16px;
-  left: 0.05rem;
+  left: 1px;
   position: absolute;
   top: calc(50% - 0.5rem);
   width: 16px;
@@ -344,16 +344,25 @@ exports[`Input should render correctly with type="radio" 1`] = `
 .c4 {
   margin-right: 0.5rem;
   background: #FFF;
-  border: 2px solid #999B9E;
+  border: 2px solid #CCC;
+  box-sizing: border-box;
   border-radius: 50%;
-  height: 1.25rem;
-  width: 1.25rem;
+  height: 16px;
+  width: 16px;
 }
 
 .c1 {
+  position: absolute;
+  border: 0;
   -webkit-clip: rect(0,0,0,0);
   clip: rect(0,0,0,0);
-  position: absolute;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  visibility: visible;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .c1:checked ~ label .c3 {
@@ -376,14 +385,15 @@ exports[`Input should render correctly with type="radio" 1`] = `
   border-radius: 51%;
   content: '';
   display: inline-block;
-  height: 0.75rem;
-  width: 0.75rem;
+  height: 8px;
+  width: 8px;
   position: relative;
   background: #10ADE4;
 }
 
 .c2 {
   position: relative;
+  left: 1px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -393,7 +403,6 @@ exports[`Input should render correctly with type="radio" 1`] = `
   -ms-flex-align: center;
   align-items: center;
   min-height: 1rem;
-  padding-left: 0.5rem;
   cursor: pointer;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-size: 1rem;

--- a/src/Tools/theme.js
+++ b/src/Tools/theme.js
@@ -31,7 +31,7 @@ const theme = {
   inputBackgroundColorFocus: palette.gray0,
   inputBorderColor: palette.gray2,
   inputBorderRadius: borderRadius,
-  inputCheckboxColor: palette.cerulean,
+  inputCheckedColor: palette.cerulean,
   inputColor: palette.gray5,
   inputPlaceholderColor: palette.gray3,
   inputRadioCheckedColor: palette.cerulean,


### PR DESCRIPTION
Make color, size and padding consistent between checkbox and radio input.
Also protect the consumer from box-sizing issues.

BEFORE:
![2018-11-08-104915_121x85_scrot](https://user-images.githubusercontent.com/5734722/48194280-7c731c00-e344-11e8-95bf-c5923eb922bb.png)
![2018-11-08-104921_121x88_scrot](https://user-images.githubusercontent.com/5734722/48194283-7e3cdf80-e344-11e8-9d69-93ea937930a2.png)

AFTER:
![2018-11-08-104659_108x86_scrot](https://user-images.githubusercontent.com/5734722/48194297-84cb5700-e344-11e8-93f6-9a499f02a341.png)
![2018-11-08-104705_110x78_scrot](https://user-images.githubusercontent.com/5734722/48194300-86951a80-e344-11e8-9c1c-242d7a2bbc1e.png)
