### PR TITLE
fix(toast): correct svg sizing for firefox

### DIFF
--- a/src/Molecules/Toasts/Toast.js
+++ b/src/Molecules/Toasts/Toast.js
@@ -1,7 +1,7 @@
 // @flow strict
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { type ReactComponentFunctional } from 'styled-components'
+import styled, { css, type ReactComponentFunctional } from 'styled-components'
 
 import injectE2E, { type E2ePropType } from '../../Tools/injectE2E'
 import {
@@ -47,11 +47,13 @@ const Close = styled.div`
   padding-left: ${PADDING};
 `
 
-const IndicatorSuccess = styled(FasCheckCircle).attrs({
-  size: '1rem',
-})`
+const IndicatorCss = css`
   margin-right: ${PADDING};
   margin-top: 2px;
+`
+
+const IndicatorSuccess = styled(FasCheckCircle)`
+  ${IndicatorCss};
   fill: ${(props) => props.theme.successColor};
 
   &:hover {
@@ -59,11 +61,8 @@ const IndicatorSuccess = styled(FasCheckCircle).attrs({
   }
 `
 
-const IndicatorWarning = styled(FasExclamationCircle).attrs({
-  size: '1rem',
-})`
-  margin-right: ${PADDING};
-  margin-top: 2px;
+const IndicatorWarning = styled(FasExclamationCircle)`
+  ${IndicatorCss};
   fill: ${(props) => props.theme.warningColor};
 
   &:hover {
@@ -71,11 +70,8 @@ const IndicatorWarning = styled(FasExclamationCircle).attrs({
   }
 `
 
-const IndicatorDanger = styled(IndicatorWarning).attrs({
-  size: '1rem',
-})`
-  margin-right: ${PADDING};
-  margin-top: 2px;
+const IndicatorDanger = styled(IndicatorWarning)`
+  ${IndicatorCss};
   fill: ${(props) => props.theme.dangerColor};
 
   &:hover {
@@ -93,9 +89,9 @@ type PropsType = {
 
 const Toast = ({ description, onClose, title, type, ...rest }: PropsType) => (
   <Wrapper {...rest}>
-    {type === 'success' && <IndicatorSuccess />}
-    {type === 'warning' && <IndicatorWarning />}
-    {type === 'danger' && <IndicatorDanger />}
+    {type === 'success' && <IndicatorSuccess size="16px" />}
+    {type === 'warning' && <IndicatorWarning size="16px" />}
+    {type === 'danger' && <IndicatorDanger size="16px" />}
     <Content>
       <Title>{title}</Title>
       {description != null && <Description>{description}</Description>}

--- a/src/Molecules/Toasts/__snapshots__/Toast.spec.js.snap
+++ b/src/Molecules/Toasts/__snapshots__/Toast.spec.js.snap
@@ -346,34 +346,36 @@ exports[`Toast should render correctly with type=danger 1`] = `
       className="c0"
       data-e2e="defaultToast"
     >
-      <Styled(Styled(FasExclamationCircle))>
+      <Styled(Styled(FasExclamationCircle))
+        size="16px"
+      >
         <Styled(FasExclamationCircle)
           className="c1"
-          size="1rem"
+          size="16px"
         >
           <FasExclamationCircle
             className="c1 c2"
             selectable={false}
-            size="1rem"
+            size="16px"
           >
             <Styled(SvgFasExclamationCircle)
               className="c1 c2"
-              height="1rem"
+              height="16px"
               selectable={0}
-              width="1rem"
+              width="16px"
             >
               <SvgFasExclamationCircle
                 className="c1 c2 c3"
-                height="1rem"
+                height="16px"
                 selectable={0}
-                width="1rem"
+                width="16px"
               >
                 <svg
                   className="c1 c2 c3"
-                  height="1rem"
+                  height="16px"
                   selectable={0}
                   viewBox="0 0 512 512"
-                  width="1rem"
+                  width="16px"
                 >
                   <path
                     d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
@@ -534,30 +536,32 @@ exports[`Toast should render correctly with type=success 1`] = `
       className="c0"
       data-e2e="defaultToast"
     >
-      <Styled(FasCheckCircle)>
+      <Styled(FasCheckCircle)
+        size="16px"
+      >
         <FasCheckCircle
           className="c1"
           selectable={false}
-          size="1rem"
+          size="16px"
         >
           <Styled(SvgFasCheckCircle)
             className="c1"
-            height="1rem"
+            height="16px"
             selectable={0}
-            width="1rem"
+            width="16px"
           >
             <SvgFasCheckCircle
               className="c1 c2"
-              height="1rem"
+              height="16px"
               selectable={0}
-              width="1rem"
+              width="16px"
             >
               <svg
                 className="c1 c2"
-                height="1rem"
+                height="16px"
                 selectable={0}
                 viewBox="0 0 512 512"
-                width="1rem"
+                width="16px"
               >
                 <path
                   d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
@@ -717,30 +721,32 @@ exports[`Toast should render correctly with type=warning 1`] = `
       className="c0"
       data-e2e="defaultToast"
     >
-      <Styled(FasExclamationCircle)>
+      <Styled(FasExclamationCircle)
+        size="16px"
+      >
         <FasExclamationCircle
           className="c1"
           selectable={false}
-          size="1rem"
+          size="16px"
         >
           <Styled(SvgFasExclamationCircle)
             className="c1"
-            height="1rem"
+            height="16px"
             selectable={0}
-            width="1rem"
+            width="16px"
           >
             <SvgFasExclamationCircle
               className="c1 c2"
-              height="1rem"
+              height="16px"
               selectable={0}
-              width="1rem"
+              width="16px"
             >
               <svg
                 className="c1 c2"
-                height="1rem"
+                height="16px"
                 selectable={0}
                 viewBox="0 0 512 512"
-                width="1rem"
+                width="16px"
               >
                 <path
                   d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"


### PR DESCRIPTION
Can use either px or em for the sizing.

Before: 
![screen shot 2018-11-08 at 1 09 55 pm](https://user-images.githubusercontent.com/39777266/48225518-07ffa380-e36b-11e8-8fb0-1e6c01ff8660.png)

After:
![screen shot 2018-11-08 at 3 29 14 pm](https://user-images.githubusercontent.com/39777266/48225532-12ba3880-e36b-11e8-8d21-dc9091572b53.png)

